### PR TITLE
Fix make_homogeneous_mode_space when a site does not allow the DoF

### DIFF
--- a/src/casm/clexulator/DoFSpace.cc
+++ b/src/casm/clexulator/DoFSpace.cc
@@ -479,7 +479,11 @@ Eigen::MatrixXd make_homogeneous_mode_space(DoFSpace const &dof_space) {
       Eigen::MatrixXd::Identity(standard_basis_dim, standard_basis_dim);
   Eigen::MatrixXd prod = I;
   for (auto const &sublat_dof : prim_dof_info) {
-    prod = sublat_dof.basis() * sublat_dof.inv_basis() * prod;
+    if (sublat_dof.dim() == 0) {
+      prod *= 0.0;
+    } else {
+      prod = sublat_dof.basis() * sublat_dof.inv_basis() * prod;
+    }
   }
   // common_standard_basis is nullspace of (prod - I):
   Eigen::MatrixXd common_standard_basis =


### PR DESCRIPTION
This fixes an error that caused a failure when constructing the homogeneous mode space when sites did not allow a particular DoF.